### PR TITLE
Improve lobby UI with session code

### DIFF
--- a/GameFinder/ApiHandler.cs
+++ b/GameFinder/ApiHandler.cs
@@ -100,12 +100,20 @@ namespace GameFinder
 
         public async Task JoinSessionAsync(string sessionCode, string username, List<string> gameList)
         {
-            if (Connection != null) await Connection.InvokeAsync("JoinSession", sessionCode, username, gameList);
+            SessionId = sessionCode;
+            if (Connection != null)
+            {
+                await Connection.InvokeAsync("JoinSession", sessionCode, username, gameList);
+            }
         }
         
         public async Task LeaveSessionAsync(string username)
         {
-            if (Connection != null) await Connection.InvokeAsync("LeaveSession", SessionId, username);
+            if (Connection != null)
+            {
+                await Connection.InvokeAsync("LeaveSession", SessionId, username);
+            }
+            SessionId = string.Empty;
         }
 
         public async Task StartSession(string sessionCode)
@@ -120,7 +128,11 @@ namespace GameFinder
 
         public async Task EndSession(string sessionCode)
         {
-            if (Connection != null) await Connection.InvokeAsync("EndSession", sessionCode);
+            if (Connection != null)
+            {
+                await Connection.InvokeAsync("EndSession", sessionCode);
+            }
+            SessionId = string.Empty;
         }
     }
 }

--- a/GameFinder/Controls/SessionLobby.xaml
+++ b/GameFinder/Controls/SessionLobby.xaml
@@ -9,6 +9,11 @@
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity">
     <Grid>
         <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="5">
+                <TextBlock Text="{Binding SessionId, StringFormat='Session Code: {0}'}"
+                           VerticalAlignment="Center" FontWeight="Bold" Margin="0,0,5,0"/>
+                <Button Content="Copy" Padding="5" Click="CopyCode_OnClick"/>
+            </StackPanel>
             <ListBox x:Name="UsersListBox" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="5" BorderBrush="Gray">
                 <ListBox.ItemTemplate>
                     <DataTemplate>

--- a/GameFinder/Controls/SessionLobby.xaml.cs
+++ b/GameFinder/Controls/SessionLobby.xaml.cs
@@ -11,9 +11,23 @@ namespace GameFinder.Controls
         private readonly ObservableCollection<string> _admins = new();
         private bool _isAdmin;
         private string _currentUser = string.Empty;
+        private string _sessionId = string.Empty;
 
         public event PropertyChangedEventHandler? PropertyChanged;
         public event EventHandler<string>? StartButtonClicked;
+
+        public string SessionId
+        {
+            get => _sessionId;
+            private set
+            {
+                if (_sessionId != value)
+                {
+                    _sessionId = value;
+                    OnPropertyChanged(nameof(SessionId));
+                }
+            }
+        }
 
         public bool IsAdmin
         {
@@ -34,6 +48,8 @@ namespace GameFinder.Controls
             InitializeComponent();
             DataContext = this;
             UsersListBox.ItemsSource = _users;
+
+            SessionId = App.Api.SessionId;
             
             SetCurrentUser(Config.Username);
             App.Api.UserJoinedSession += AddUser;
@@ -106,6 +122,18 @@ namespace GameFinder.Controls
             App.Api.UserJoinedSession -= AddUser;
             App.Api.UserLeftSession -= RemoveUser;
             App.Api.SessionStarted -= OnSessionStarted;
+        }
+
+        private void CopyCode_OnClick(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                Clipboard.SetText(SessionId);
+            }
+            catch (Exception)
+            {
+                // ignore clipboard errors
+            }
         }
 
         private void OnPropertyChanged(string propertyName)


### PR DESCRIPTION
## Summary
- show session code in the session lobby and allow copying it
- store the session ID when joining and clear it on leave/end

## Testing
- `dotnet build GameFinderApi/GameFinderApi.csproj -c Release`
- `dotnet build Solution1.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_684310a9862c8320bd2a912cc9ec8fd0