### PR TITLE
Add Avalonia client

### DIFF
--- a/GameFinderAvalonia/ApiHandler.cs
+++ b/GameFinderAvalonia/ApiHandler.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Client;
+using GameFinderAvalonia;
+
+namespace GameFinderAvalonia
+{
+    public class ApiHandler
+    {
+        public HubConnection? Connection { get; set; }
+        public string SessionId { get; private set; } = string.Empty;
+
+        // Define events
+        public event Action<string>? SessionCreated;
+        public event Action<string, bool>? UserJoinedSession;
+        public event Action<string>? UserLeftSession;
+        public event Action<IEnumerable<string>>? SessionStarted;
+        public event Action<string, string, bool>? UserSwiped;
+        public event Action<string>? GameMatched;
+        public event Action<string>? ErrorOccurred;
+        public event Action<string?>? SessionEnded;
+
+        public async Task Connect(string[] args)
+        {
+            string hubUrl = "http://127.0.0.1:5170/matchinghub"; // Replace with your SignalR hub URL
+
+            Connection = new HubConnectionBuilder()
+                .WithUrl(hubUrl)
+                .Build();
+
+            RegisterEventHandlers(Connection);
+
+            await Connection.StartAsync();
+            Console.WriteLine("Connected to the hub.");
+        }
+
+        private void RegisterEventHandlers(HubConnection connection)
+        {
+            connection.On<string>("SessionCreated", (sessionCode) =>
+            {
+                SessionId = sessionCode;
+                Console.WriteLine($"Session created with code: {sessionCode}");
+                SessionCreated?.Invoke(sessionCode);
+            });
+
+            connection.On<string, bool>("JoinedSession", (username, admin) =>
+            {
+                Console.WriteLine($"{username} joined");
+                if (admin)
+                {
+                    Console.WriteLine("User is admin");
+                }
+                UserJoinedSession?.Invoke(username, admin);
+            });
+
+            // Assuming a "LeftSession" event exists in your SignalR hub
+            connection.On<string>("LeftSession", (username) =>
+            {
+                Console.WriteLine($"{username} left");
+                UserLeftSession?.Invoke(username);
+            });
+
+            connection.On<IEnumerable<string>>("SessionStarted", (commonGames) =>
+            {
+                Console.WriteLine("Session started. Common games:");
+                Config.CommonGames = commonGames.ToList();
+                SessionStarted?.Invoke(commonGames);
+            });
+
+            connection.On<string, string, bool>("UserSwiped", (userId, game, swipeRight) =>
+            {
+                Console.WriteLine($"User {userId} swiped {(swipeRight ? "right" : "left")} on {game}");
+                UserSwiped?.Invoke(userId, game, swipeRight);
+            });
+
+            connection.On<string>("GameMatched", (game) =>
+            {
+                Console.WriteLine($"Game matched: {game}");
+                GameMatched?.Invoke(game);
+            });
+
+            connection.On<string?>("SessionEnded", (game) =>
+            {
+                Console.WriteLine($"Session ended. Matched game: {game}");
+                SessionEnded?.Invoke(game);
+            });
+
+            connection.On<string>("Error", (errorMessage) =>
+            {
+                Console.WriteLine($"Error occurred: {errorMessage}");
+                ErrorOccurred?.Invoke(errorMessage);
+            });
+        }
+
+        public async Task CreateSessionAsync()
+        {
+            if (Connection != null) await Connection.InvokeAsync("CreateSession");
+        }
+
+        public async Task JoinSessionAsync(string sessionCode, string username, List<string> gameList)
+        {
+            SessionId = sessionCode;
+            if (Connection != null)
+            {
+                await Connection.InvokeAsync("JoinSession", sessionCode, username, gameList);
+            }
+        }
+        
+        public async Task LeaveSessionAsync(string username)
+        {
+            if (Connection != null)
+            {
+                await Connection.InvokeAsync("LeaveSession", SessionId, username);
+            }
+            SessionId = string.Empty;
+        }
+
+        public async Task StartSession(string sessionCode)
+        {
+            if (Connection != null) await Connection.InvokeAsync("StartSession", sessionCode);
+        }
+
+        public async Task Swipe(string sessionCode, string game, bool swipeRight)
+        {
+            if (Connection != null) await Connection.InvokeAsync("Swipe", sessionCode, game, swipeRight);
+        }
+
+        public async Task EndSession(string sessionCode)
+        {
+            if (Connection != null)
+            {
+                await Connection.InvokeAsync("EndSession", sessionCode);
+            }
+            SessionId = string.Empty;
+        }
+    }
+}

--- a/GameFinderAvalonia/App.axaml
+++ b/GameFinderAvalonia/App.axaml
@@ -1,0 +1,10 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GameFinderAvalonia.App"
+             RequestedThemeVariant="Default">
+             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/GameFinderAvalonia/App.axaml.cs
+++ b/GameFinderAvalonia/App.axaml.cs
@@ -1,0 +1,26 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace GameFinderAvalonia;
+
+public partial class App : Application
+{
+    public static ApiHandler Api { get; } = new ApiHandler();
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override async void OnFrameworkInitializationCompleted()
+    {
+        await Api.Connect(Config.GameList.ToArray());
+
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/GameFinderAvalonia/Config.cs
+++ b/GameFinderAvalonia/Config.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace GameFinderAvalonia;
+
+public static class Config
+{
+    public static string Username { get; set; } = string.Empty;
+    public static List<string> GameList = new List<string>();
+    public static List<string> CommonGames = new List<string>();
+}

--- a/GameFinderAvalonia/GameFinderAvalonia.csproj
+++ b/GameFinderAvalonia/GameFinderAvalonia.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.26.1" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.0">
+      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
+      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/GameFinderAvalonia/MainWindow.axaml
+++ b/GameFinderAvalonia/MainWindow.axaml
@@ -1,0 +1,9 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="GameFinderAvalonia.MainWindow"
+        Title="GameFinderAvalonia">
+    Welcome to Avalonia!
+</Window>

--- a/GameFinderAvalonia/MainWindow.axaml.cs
+++ b/GameFinderAvalonia/MainWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace GameFinderAvalonia;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/GameFinderAvalonia/Objects/CookieData.cs
+++ b/GameFinderAvalonia/Objects/CookieData.cs
@@ -1,0 +1,37 @@
+using System;
+using OpenQA.Selenium;
+
+namespace GameFinderAvalonia.Objects;
+
+public class CookieData
+{
+    public string Name { get; set; }
+    public string Value { get; set; }
+    public string Domain { get; set; }
+    public string Path { get; set; }
+    public DateTime? Expiry { get; set; }
+    public bool Secure { get; set; }
+    public bool HttpOnly { get; set; }
+    public string SameSite { get; set; }
+
+    public CookieData()
+    {
+    }
+
+    public CookieData(Cookie cookie)
+    {
+        Name = cookie.Name;
+        Value = cookie.Value;
+        Domain = cookie.Domain;
+        Path = cookie.Path;
+        Expiry = cookie.Expiry;
+        Secure = cookie.Secure;
+        HttpOnly = cookie.IsHttpOnly;
+        SameSite = cookie.SameSite;
+    }
+
+    public Cookie ToSeleniumCookie()
+    {
+        return new Cookie(Name, Value, Domain, Path, Expiry, Secure, HttpOnly, SameSite);
+    }
+}

--- a/GameFinderAvalonia/Objects/SteamResponse.cs
+++ b/GameFinderAvalonia/Objects/SteamResponse.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GameFinderAvalonia.Objects
+{
+    public class SteamGameResponse
+    {
+        public bool Success { get; set; }
+        public GameData Data { get; set; }
+    }
+
+    public class GameData
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+        [JsonPropertyName("type")]
+        public string AppType { get; set; }
+        [JsonPropertyName("short_description")]
+        public string ShortDescription { get; set; }
+        [JsonPropertyName("header_image")]
+        public string HeaderImage { get; set; }
+        [JsonPropertyName("genres")]
+        public List<Genre> Genres { get; set; }    
+        [JsonPropertyName("categories")]
+        public List<Category> Categories { get; set; }
+        [JsonPropertyName("supported_languages")]
+        public string SupportedLanguages { get; set; }
+        public Recommendations Recommendations { get; set; }
+    }
+
+    public class Category
+    {
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+    }
+
+    public class Genre
+    {
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+    }
+
+    public class Recommendations
+    {
+        [JsonPropertyName("total")]
+        public int Total { get; set; }
+    }
+}

--- a/GameFinderAvalonia/Program.cs
+++ b/GameFinderAvalonia/Program.cs
@@ -1,0 +1,21 @@
+﻿using Avalonia;
+using System;
+
+namespace GameFinderAvalonia;
+
+class Program
+{
+    // Initialization code. Don't use any Avalonia, third-party APIs or any
+    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+    // yet and stuff might break.
+    [STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp()
+        .StartWithClassicDesktopLifetime(args);
+
+    // Avalonia configuration, don't remove; also used by visual designer.
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace();
+}

--- a/GameFinderAvalonia/Utils/UiHelperExtensions.cs
+++ b/GameFinderAvalonia/Utils/UiHelperExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Avalonia.Threading;
+
+namespace GameFinderAvalonia.Helpers
+{
+    public static class UiHelper
+    {
+        public static void SafeInvoke(Action action)
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                action();
+            }
+            else
+            {
+                Dispatcher.UIThread.Post(action);
+            }
+        }
+    }
+}

--- a/GameFinderAvalonia/app.manifest
+++ b/GameFinderAvalonia/app.manifest
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- This manifest is used on Windows only.
+       Don't remove it as it might cause problems with window transparency and embedded controls.
+       For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
+  <assemblyIdentity version="1.0.0.0" name="GameFinderAvalonia.Desktop"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/Solution1.sln
+++ b/Solution1.sln
@@ -1,10 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp1", "ConsoleApp1\ConsoleApp1.csproj", "{FF4D8487-6BED-4161-9166-EE0C06588F3A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameFinder", "GameFinder\GameFinder.csproj", "{0B683F0D-91F3-4A57-90D3-F606B3A55E92}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameFinderApi", "GameFinderApi\GameFinderApi.csproj", "{53C1EDF1-FAE3-43C5-851F-1BB564A146EC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameFinderAvalonia", "GameFinderAvalonia\GameFinderAvalonia.csproj", "{B5EEA7DC-90B6-4832-BDD4-E494FA915F97}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,13 +17,13 @@ Global
 		{FF4D8487-6BED-4161-9166-EE0C06588F3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF4D8487-6BED-4161-9166-EE0C06588F3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF4D8487-6BED-4161-9166-EE0C06588F3A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0B683F0D-91F3-4A57-90D3-F606B3A55E92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0B683F0D-91F3-4A57-90D3-F606B3A55E92}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0B683F0D-91F3-4A57-90D3-F606B3A55E92}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0B683F0D-91F3-4A57-90D3-F606B3A55E92}.Release|Any CPU.Build.0 = Release|Any CPU
 		{53C1EDF1-FAE3-43C5-851F-1BB564A146EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{53C1EDF1-FAE3-43C5-851F-1BB564A146EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{53C1EDF1-FAE3-43C5-851F-1BB564A146EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{53C1EDF1-FAE3-43C5-851F-1BB564A146EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5EEA7DC-90B6-4832-BDD4-E494FA915F97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5EEA7DC-90B6-4832-BDD4-E494FA915F97}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5EEA7DC-90B6-4832-BDD4-E494FA915F97}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5EEA7DC-90B6-4832-BDD4-E494FA915F97}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- remove WPF app from solution
- introduce a new `GameFinderAvalonia` cross‑platform project
- connect to the backend from Avalonia `App` startup
- include helper for UI thread marshaling

## Testing
- `dotnet build GameFinderAvalonia/GameFinderAvalonia.csproj -c Release`
- `dotnet build Solution1.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6843537c6c208320ac2f5c7efcb1be53