### PR TITLE
Fix Windows workflow publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,14 @@ jobs:
         with:
           dotnet-version: '9.0.x'
       - name: Publish client
+        shell: bash
         run: |
           dotnet publish GameFinderAvalonia/GameFinderAvalonia.csproj \
             -c Release -r ${{ matrix.rid }} --self-contained true \
             -p:PublishSingleFile=true -p:PublishTrimmed=true \
             -o client
       - name: Publish server
+        shell: bash
         run: |
           dotnet publish GameFinderApi/GameFinderApi.csproj \
             -c Release -r ${{ matrix.rid }} --self-contained true \


### PR DESCRIPTION
## Summary
- ensure the publish steps use bash so the line continuations work on Windows

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6843646337488320bbb8ac6cc5b6903e