### PR TITLE
Add basic Avalonia UI

### DIFF
--- a/GameFinderAvalonia/MainWindow.axaml
+++ b/GameFinderAvalonia/MainWindow.axaml
@@ -1,9 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        xmlns:views="clr-namespace:GameFinderAvalonia.Views"
         x:Class="GameFinderAvalonia.MainWindow"
-        Title="GameFinderAvalonia">
-    Welcome to Avalonia!
+        Title="GameFinder">
+    <views:Tabs x:Name="TabsControl" />
 </Window>

--- a/GameFinderAvalonia/MainWindow.axaml.cs
+++ b/GameFinderAvalonia/MainWindow.axaml.cs
@@ -1,11 +1,15 @@
 using Avalonia.Controls;
+using GameFinderAvalonia.Views;
 
 namespace GameFinderAvalonia;
 
 public partial class MainWindow : Window
 {
+    private Tabs _tabs;
     public MainWindow()
     {
         InitializeComponent();
+        _tabs = this.FindControl<Tabs>("TabsControl");
+        App.Api.SessionEnded += game => _tabs.ShowResults(game);
     }
 }

--- a/GameFinderAvalonia/Views/MatchResult.axaml
+++ b/GameFinderAvalonia/Views/MatchResult.axaml
@@ -1,0 +1,8 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GameFinderAvalonia.Views.MatchResult">
+    <StackPanel Margin="20" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <TextBlock x:Name="Result" FontSize="20" FontWeight="Bold"/>
+        <Button Content="Back" Click="Back" Margin="10" HorizontalAlignment="Center"/>
+    </StackPanel>
+</UserControl>

--- a/GameFinderAvalonia/Views/MatchResult.axaml.cs
+++ b/GameFinderAvalonia/Views/MatchResult.axaml.cs
@@ -1,0 +1,21 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using System;
+
+namespace GameFinderAvalonia.Views;
+
+public partial class MatchResult : UserControl
+{
+    public event EventHandler? BackClicked;
+
+    public MatchResult(string? game)
+    {
+        InitializeComponent();
+        Result.Text = string.IsNullOrEmpty(game) ? "No common game" : $"Play {game}";
+    }
+
+    private void Back(object? sender, RoutedEventArgs e)
+    {
+        BackClicked?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/GameFinderAvalonia/Views/SessionLobby.axaml
+++ b/GameFinderAvalonia/Views/SessionLobby.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GameFinderAvalonia.Views.SessionLobby">
+    <StackPanel Margin="20">
+        <TextBlock Text="Session Lobby" FontWeight="Bold" FontSize="20"/>
+        <TextBlock x:Name="CodeText" Margin="0,5,0,5"/>
+        <ListBox x:Name="Users" Height="150" />
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Button Content="Leave" Click="Leave" Margin="5"/>
+            <Button x:Name="Start" Content="Start" Click="StartSession" Margin="5"/>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/GameFinderAvalonia/Views/SessionLobby.axaml.cs
+++ b/GameFinderAvalonia/Views/SessionLobby.axaml.cs
@@ -1,0 +1,44 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using System;
+using System.Collections.ObjectModel;
+using GameFinderAvalonia.Helpers;
+
+namespace GameFinderAvalonia.Views;
+
+public partial class SessionLobby : UserControl
+{
+    private ObservableCollection<string> _users = new();
+    public event EventHandler? StartClicked;
+
+    public SessionLobby()
+    {
+        InitializeComponent();
+        Users.ItemsSource = _users;
+        CodeText.Text = $"Code: {App.Api.SessionId}";
+        App.Api.UserJoinedSession += OnUserJoined;
+        App.Api.UserLeftSession += OnUserLeft;
+    }
+
+    private void OnUserJoined(string user, bool admin)
+    {
+        UiHelper.SafeInvoke(() => _users.Add(user));
+    }
+
+    private void OnUserLeft(string user)
+    {
+        UiHelper.SafeInvoke(() => _users.Remove(user));
+    }
+
+    private async void StartSession(object? sender, RoutedEventArgs e)
+    {
+        await App.Api.StartSession(App.Api.SessionId);
+        StartClicked?.Invoke(this, EventArgs.Empty);
+    }
+
+    private async void Leave(object? sender, RoutedEventArgs e)
+    {
+        await App.Api.LeaveSessionAsync(Config.Username);
+        StartClicked?.Invoke(this, EventArgs.Empty); // go back
+    }
+}

--- a/GameFinderAvalonia/Views/SessionStart.axaml
+++ b/GameFinderAvalonia/Views/SessionStart.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GameFinderAvalonia.Views.SessionStart">
+    <StackPanel Margin="20" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <TextBox x:Name="NameBox" Width="200" Watermark="Display name"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Button Content="Start New Session" Click="StartNewSession" Margin="5"/>
+            <Button Content="Join Session" Click="JoinSession" Margin="5"/>
+        </StackPanel>
+        <TextBox x:Name="SessionCode" Width="200" Watermark="Code" Margin="0,10,0,0"/>
+    </StackPanel>
+</UserControl>

--- a/GameFinderAvalonia/Views/SessionStart.axaml.cs
+++ b/GameFinderAvalonia/Views/SessionStart.axaml.cs
@@ -1,0 +1,31 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using System;
+using System.Threading.Tasks;
+
+namespace GameFinderAvalonia.Views;
+
+public partial class SessionStart : UserControl
+{
+    public event EventHandler? SessionAction;
+
+    public SessionStart()
+    {
+        InitializeComponent();
+    }
+
+    private async void StartNewSession(object? sender, RoutedEventArgs e)
+    {
+        Config.Username = NameBox.Text ?? string.Empty;
+        await App.Api.CreateSessionAsync();
+        await App.Api.JoinSessionAsync(App.Api.SessionId, Config.Username, Config.GameList);
+        SessionAction?.Invoke(this, EventArgs.Empty);
+    }
+
+    private async void JoinSession(object? sender, RoutedEventArgs e)
+    {
+        Config.Username = NameBox.Text ?? string.Empty;
+        await App.Api.JoinSessionAsync(SessionCode.Text ?? string.Empty, Config.Username, Config.GameList);
+        SessionAction?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/GameFinderAvalonia/Views/Swiping.axaml
+++ b/GameFinderAvalonia/Views/Swiping.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GameFinderAvalonia.Views.Swiping">
+    <StackPanel Margin="20" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Image x:Name="GameImage" Width="300" Height="150"/>
+        <TextBlock x:Name="GameName" FontSize="20" FontWeight="Bold" Margin="0,5,0,0"/>
+        <TextBlock x:Name="Description" TextWrapping="Wrap" Width="300"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Button Content="Dislike" Click="Dislike" Margin="5"/>
+            <Button Content="Like" Click="Like" Margin="5"/>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/GameFinderAvalonia/Views/Swiping.axaml.cs
+++ b/GameFinderAvalonia/Views/Swiping.axaml.cs
@@ -1,0 +1,55 @@
+using Avalonia.Controls;
+using Avalonia.Media.Imaging;
+using Avalonia.Interactivity;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GameFinderAvalonia.Objects;
+
+namespace GameFinderAvalonia.Views;
+
+public partial class Swiping : UserControl
+{
+    private Queue<string> _queue;
+    private HttpClient _http = new HttpClient();
+    private string? _current;
+
+    public Swiping()
+    {
+        InitializeComponent();
+        _queue = new Queue<string>(Config.CommonGames);
+        Loaded += async (_, _) => await LoadNext();
+    }
+
+    private async Task LoadNext()
+    {
+        if (_queue.Count == 0)
+        {
+            App.Api.EndSession(App.Api.SessionId);
+            return;
+        }
+        _current = _queue.Dequeue();
+        var json = await _http.GetStringAsync($"http://127.0.0.1:5170/SteamMarketData/{_current}");
+        var data = JsonSerializer.Deserialize<SteamGameResponse>(json)?.Data;
+        if (data != null)
+        {
+            GameName.Text = data.Name;
+            Description.Text = data.ShortDescription;
+            GameImage.Source = new Bitmap(data.HeaderImage);
+        }
+    }
+
+    private async void Like(object? sender, RoutedEventArgs e)
+    {
+        if (_current != null) await App.Api.Swipe(App.Api.SessionId, _current, true);
+        await LoadNext();
+    }
+
+    private async void Dislike(object? sender, RoutedEventArgs e)
+    {
+        if (_current != null) await App.Api.Swipe(App.Api.SessionId, _current, false);
+        await LoadNext();
+    }
+}

--- a/GameFinderAvalonia/Views/Tabs.axaml
+++ b/GameFinderAvalonia/Views/Tabs.axaml
@@ -1,0 +1,22 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:GameFinderAvalonia.Views"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             x:Class="GameFinderAvalonia.Views.Tabs"
+             mc:Ignorable="d">
+    <Grid>
+        <TabControl>
+            <TabItem Header="Home">
+                <StackPanel Margin="10">
+                    <TextBlock TextWrapping="Wrap">
+                        Enter your display name and start or join a session.
+                    </TextBlock>
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="Session">
+                <ContentControl x:Name="SessionContent" />
+            </TabItem>
+        </TabControl>
+    </Grid>
+</UserControl>

--- a/GameFinderAvalonia/Views/Tabs.axaml.cs
+++ b/GameFinderAvalonia/Views/Tabs.axaml.cs
@@ -1,0 +1,40 @@
+using Avalonia.Controls;
+using System;
+
+namespace GameFinderAvalonia.Views;
+
+public partial class Tabs : UserControl
+{
+    public Tabs()
+    {
+        InitializeComponent();
+        ShowSessionStart();
+        App.Api.SessionEnded += game => ShowResults(game);
+    }
+
+    public void ShowSessionStart()
+    {
+        var start = new SessionStart();
+        start.SessionAction += (_, _) => ShowSessionLobby();
+        SessionContent.Content = start;
+    }
+
+    public void ShowSessionLobby()
+    {
+        var lobby = new SessionLobby();
+        lobby.StartClicked += (_, _) => ShowSwiping();
+        SessionContent.Content = lobby;
+    }
+
+    public void ShowSwiping()
+    {
+        SessionContent.Content = new Swiping();
+    }
+
+    public void ShowResults(string? gameId)
+    {
+        var result = new MatchResult(gameId);
+        result.BackClicked += (_, _) => ShowSessionStart();
+        SessionContent.Content = result;
+    }
+}


### PR DESCRIPTION
## Summary
- implement a simple Avalonia interface with tabs
- add views for session start, lobby, swiping and match result
- hook up API events

## Testing
- `dotnet build GameFinderAvalonia/GameFinderAvalonia.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68436d5b201483209beab63d7e4a910c