### PR TITLE
Add CI workflow for building and releasing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,44 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+      - name: Restore dependencies
+        run: dotnet restore Solution1.sln
+      - name: Publish projects
+        run: |
+          dotnet publish GameFinder/GameFinder.csproj -c Release -o publish/GameFinder
+          dotnet publish GameFinderApi/GameFinderApi.csproj -c Release -o publish/GameFinderApi
+          dotnet publish ConsoleApp1/ConsoleApp1.csproj -c Release -o publish/ConsoleApp1
+      - name: Create zip
+        run: Compress-Archive -Path publish\* -DestinationPath GameFinder.zip
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: GameFinder
+          path: GameFinder.zip
+
+  release:
+    needs: build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: GameFinder
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v1.${{ github.run_number }}
+          name: Release v1.${{ github.run_number }}
+          files: GameFinder.zip


### PR DESCRIPTION
## Summary
- build on each push to `main`
- publish all projects and zip the output
- upload the artifact and publish a versioned GitHub Release

## Testing
- `dotnet build Solution1.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846104400b48320a91f6366bff8df94