### PR TITLE
Update artifact actions to v4

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Create zip
         run: Compress-Archive -Path publish\* -DestinationPath GameFinder.zip
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: GameFinder
           path: GameFinder.zip
@@ -33,7 +33,7 @@ jobs:
     needs: build
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: GameFinder
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
- update GitHub workflow to use `actions/upload-artifact@v4`
- update GitHub workflow to use `actions/download-artifact@v4`

## Testing
- `dotnet build Solution1.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461118b8fc832096a2e0ee247e804d