### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -32,6 +32,8 @@ jobs:
   release:
     needs: build
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- fix softprops action 403 by granting contents write permissions

## Testing
- `dotnet restore Solution1.sln`
- `dotnet build Solution1.sln -c Release -v minimal` *(fails: missing Windows Desktop SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6846130389008320bf4649d7824a51f5