### PR TITLE
Add AGENTS file with contribution instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines for GameFinder
+
+This file provides repository-specific instructions for agents working in this codebase.
+
+## Commit Guidelines
+- Use concise commit messages that summarize the change.
+- Prefer the present tense (e.g., "Add feature" rather than "Added feature").
+
+## Code Style
+- Projects target **.NET 8**; use the same version for builds.
+- Indent C# code with **4 spaces**.
+- Use `PascalCase` for public types and methods.
+- Ensure all files end with a newline.
+
+## Programmatic Checks
+Run the following commands from the repository root before committing changes to confirm the solution builds:
+
+```bash
+dotnet restore Solution1.sln
+dotnet build --no-restore Solution1.sln
+```
+
+The solution includes a WPF project that requires the .NET Desktop SDK and will only build on Windows. If building on a non-Windows environment, you may build the API and console projects individually:
+
+```bash
+dotnet build GameFinderApi/GameFinderApi.csproj
+
+dotnet build ConsoleApp1/ConsoleApp1.csproj
+```
+
+If the repository gains unit tests, run `dotnet test` as well.
+
+## Pull Request Notes
+Include a short summary of what changed and paste the output of the build commands in the PR description.


### PR DESCRIPTION
## Summary
- add repo guidelines and instructions in `AGENTS.md`

## Testing
- `dotnet restore Solution1.sln`
- `dotnet build --no-restore Solution1.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_684620df762483208f4eeb5b9327f0cf