### PR TITLE
Add self-contained server build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,13 +13,16 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - name: Restore dependencies
         run: dotnet restore ArcadeMatch.sln
       - name: Publish projects
         run: |
           dotnet publish ArcadeMatch.Client/ArcadeMatch.Client.csproj -c Release -o publish/ArcadeMatch.Client
-          dotnet publish ArcadeMatch.Server/ArcadeMatch.Server.csproj -c Release -o publish/ArcadeMatch.Server
+          dotnet publish ArcadeMatch.Server/ArcadeMatch.Server.csproj -c Release -r win-x64 --self-contained true -o publish/ArcadeMatch.Server/win-x64
+          dotnet publish ArcadeMatch.Server/ArcadeMatch.Server.csproj -c Release -r linux-x64 --self-contained true -o publish/ArcadeMatch.Server/linux-x64
+          dotnet publish ArcadeMatch.Server/ArcadeMatch.Server.csproj -c Release -r linux-arm64 --self-contained true -o publish/ArcadeMatch.Server/linux-arm64
+          dotnet publish ArcadeMatch.Server/ArcadeMatch.Server.csproj -c Release -r linux-arm --self-contained true -o publish/ArcadeMatch.Server/linux-arm
           dotnet publish SteamCookieFetcher/SteamCookieFetcher.csproj -c Release -o publish/SteamCookieFetcher
       - name: Create zip
         run: Compress-Archive -Path publish\* -DestinationPath ArcadeMatch.zip
@@ -34,6 +37,7 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -44,3 +48,16 @@ jobs:
           tag_name: v1.${{ github.run_number }}
           name: Release v1.${{ github.run_number }}
           files: ArcadeMatch.zip
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push server image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ArcadeMatch.Server/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/server:v1.${{ github.run_number }}

--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ The API persistently caches fetched game details and throttles Steam requests wi
 4. Find your numeric Steam ID by opening your profile and copying the number from the URL (use <https://steamidfinder.com/> if you have a custom URL).
 5. Launch ArcadeMatch, open the **Config** tab, and paste your API key and Steam ID.
 6. Click **Fetch via API** to load your games without using cookies.
+
+## Releases
+GitHub releases contain prebuilt binaries for the client, the server and the
+Steam cookie utility. Server executables are provided for Windows and Linux
+(x64, arm64 and arm) as self‑contained binaries so they run without a local
+.NET installation. A Docker image of the server is also published on GitHub
+Container Registry for container deployments.


### PR DESCRIPTION
## Summary
- update release workflow to also publish Linux builds and push a Docker image
- document Linux binaries and Docker image in README

## Testing
- `dotnet restore ArcadeMatch.sln`
- `dotnet build --no-restore ArcadeMatch.sln` *(fails: WindowsDesktop SDK missing)*
- `dotnet build ArcadeMatch.Server/ArcadeMatch.Server.csproj`
- `dotnet build SteamCookieFetcher/SteamCookieFetcher.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6846d2305a848320850a81bca87dd829