### PR TITLE
Add Avalonia cross‑platform project

### DIFF
--- a/ArcadeMatch.Avalonia/App.axaml
+++ b/ArcadeMatch.Avalonia/App.axaml
@@ -1,0 +1,10 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ArcadeMatch.Avalonia.App"
+             RequestedThemeVariant="Default">
+             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/ArcadeMatch.Avalonia/App.axaml.cs
+++ b/ArcadeMatch.Avalonia/App.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace ArcadeMatch.Avalonia;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/ArcadeMatch.Avalonia/ArcadeMatch.Avalonia.csproj
+++ b/ArcadeMatch.Avalonia/ArcadeMatch.Avalonia.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.3.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.2" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.2">
+      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
+      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/ArcadeMatch.Avalonia/MainWindow.axaml
+++ b/ArcadeMatch.Avalonia/MainWindow.axaml
@@ -1,0 +1,9 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="ArcadeMatch.Avalonia.MainWindow"
+        Title="ArcadeMatch.Avalonia">
+    Welcome to Avalonia!
+</Window>

--- a/ArcadeMatch.Avalonia/MainWindow.axaml.cs
+++ b/ArcadeMatch.Avalonia/MainWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace ArcadeMatch.Avalonia;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/ArcadeMatch.Avalonia/Program.cs
+++ b/ArcadeMatch.Avalonia/Program.cs
@@ -1,0 +1,21 @@
+﻿using Avalonia;
+using System;
+
+namespace ArcadeMatch.Avalonia;
+
+class Program
+{
+    // Initialization code. Don't use any Avalonia, third-party APIs or any
+    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+    // yet and stuff might break.
+    [STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp()
+        .StartWithClassicDesktopLifetime(args);
+
+    // Avalonia configuration, don't remove; also used by visual designer.
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace();
+}

--- a/ArcadeMatch.Avalonia/app.manifest
+++ b/ArcadeMatch.Avalonia/app.manifest
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- This manifest is used on Windows only.
+       Don't remove it as it might cause problems with window transparency and embedded controls.
+       For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
+  <assemblyIdentity version="1.0.0.0" name="ArcadeMatch.Avalonia.Desktop"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/ArcadeMatch.sln
+++ b/ArcadeMatch.sln
@@ -1,10 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SteamCookieFetcher", "SteamCookieFetcher\SteamCookieFetcher.csproj", "{FF4D8487-6BED-4161-9166-EE0C06588F3A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArcadeMatch.Client", "ArcadeMatch.Client/ArcadeMatch.Client.csproj", "{0B683F0D-91F3-4A57-90D3-F606B3A55E92}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArcadeMatch.Client", "ArcadeMatch.Client\ArcadeMatch.Client.csproj", "{0B683F0D-91F3-4A57-90D3-F606B3A55E92}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArcadeMatch.Server", "ArcadeMatch.Server\ArcadeMatch.Server.csproj", "{53C1EDF1-FAE3-43C5-851F-1BB564A146EC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArcadeMatch.Avalonia", "ArcadeMatch.Avalonia\ArcadeMatch.Avalonia.csproj", "{10EF9015-6D89-47C2-8BF6-5843FE7E4DD0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +27,9 @@ Global
 		{53C1EDF1-FAE3-43C5-851F-1BB564A146EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{53C1EDF1-FAE3-43C5-851F-1BB564A146EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{53C1EDF1-FAE3-43C5-851F-1BB564A146EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10EF9015-6D89-47C2-8BF6-5843FE7E4DD0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10EF9015-6D89-47C2-8BF6-5843FE7E4DD0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10EF9015-6D89-47C2-8BF6-5843FE7E4DD0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10EF9015-6D89-47C2-8BF6-5843FE7E4DD0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add new `ArcadeMatch.Avalonia` project targeting .NET 8
- include Avalonia packages and default window
- register the project in `ArcadeMatch.sln`

## Testing
- `dotnet restore ArcadeMatch.sln`
- `dotnet build ArcadeMatch.Avalonia/ArcadeMatch.Avalonia.csproj -c Release --no-restore`
- `dotnet build ArcadeMatch.Server/ArcadeMatch.Server.csproj --no-restore -c Release`
- `dotnet build SteamCookieFetcher/SteamCookieFetcher.csproj --no-restore -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685c660b66f88320a2b331b189f0361a