### PR TITLE
Add view and view model for settings tab

### DIFF
--- a/ArcadeMatch.Avalonia/Controls/SettingsTabView.axaml
+++ b/ArcadeMatch.Avalonia/Controls/SettingsTabView.axaml
@@ -1,0 +1,25 @@
+<UserControl
+    x:Class="ArcadeMatch.Avalonia.Controls.SettingsTabView"
+    x:DataType="vm:SettingsTabViewModel"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:vm="clr-namespace:ArcadeMatch.Avalonia.ViewModels.Tabs"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="20">
+            <TextBlock
+                FontSize="20"
+                FontWeight="Bold"
+                HorizontalAlignment="Center"
+                Margin="0,0,0,20"
+                Text="Configuration" />
+            <TextBlock Text="🔐 Steam API Key" />
+            <TextBox Margin="0,0,0,20" Text="{Binding Home.SteamApiKey, Mode=TwoWay}" />
+            <TextBlock Text="🆔 Steam ID" />
+            <TextBox Margin="0,0,0,20" Text="{Binding Home.SteamId, Mode=TwoWay}" />
+            <Button
+                Command="{Binding Home.FetchViaApiCommand}"
+                Content="🔄 Fetch via API"
+                HorizontalAlignment="Center" />
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/ArcadeMatch.Avalonia/Controls/SettingsTabView.axaml.cs
+++ b/ArcadeMatch.Avalonia/Controls/SettingsTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace ArcadeMatch.Avalonia.Controls;
+
+public partial class SettingsTabView : UserControl
+{
+    public SettingsTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/ArcadeMatch.Avalonia/Controls/Tabs.axaml
+++ b/ArcadeMatch.Avalonia/Controls/Tabs.axaml
@@ -11,6 +11,9 @@
         <converters:IsLoggedInToBrushConverter x:Key="IsLoggedInToBrushConverter" />
     </UserControl.Resources>
     <UserControl.DataTemplates>
+        <DataTemplate DataType="{x:Type vm:SettingsTabViewModel}">
+            <controls:SettingsTabView />
+        </DataTemplate>
         <DataTemplate DataType="{x:Type sessionVm:SessionStartViewModel}">
             <controls:SessionStart />
         </DataTemplate>
@@ -74,24 +77,7 @@
             <ContentControl Content="{Binding SelectedSession}" />
         </TabItem>
         <TabItem Header="Settings">
-            <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <StackPanel Margin="20">
-                    <TextBlock
-                        FontSize="20"
-                        FontWeight="Bold"
-                        HorizontalAlignment="Center"
-                        Margin="0,0,0,20"
-                        Text="Configuration" />
-                    <TextBlock Text="🔐 Steam API Key" />
-                    <TextBox Margin="0,0,0,20" Text="{Binding Home.SteamApiKey, Mode=TwoWay}" />
-                    <TextBlock Text="🆔 Steam ID" />
-                    <TextBox Margin="0,0,0,20" Text="{Binding Home.SteamId, Mode=TwoWay}" />
-                    <Button
-                        Command="{Binding Home.FetchViaApiCommand}"
-                        Content="🔄 Fetch via API"
-                        HorizontalAlignment="Center" />
-                </StackPanel>
-            </ScrollViewer>
+            <ContentControl Content="{Binding Settings}" />
         </TabItem>
     </TabControl>
 </UserControl>

--- a/ArcadeMatch.Avalonia/ViewModels/Tabs/SettingsTabViewModel.cs
+++ b/ArcadeMatch.Avalonia/ViewModels/Tabs/SettingsTabViewModel.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace ArcadeMatch.Avalonia.ViewModels.Tabs;
+
+public class SettingsTabViewModel
+{
+    public SettingsTabViewModel(HomeTabViewModel home)
+    {
+        Home = home ?? throw new ArgumentNullException(nameof(home));
+    }
+
+    public HomeTabViewModel Home { get; }
+}

--- a/ArcadeMatch.Avalonia/ViewModels/Tabs/TabsViewModel.cs
+++ b/ArcadeMatch.Avalonia/ViewModels/Tabs/TabsViewModel.cs
@@ -12,6 +12,7 @@ public class TabsViewModel : INotifyPropertyChanged
     public TabsViewModel(ISteamGameService steamGameService, IUserConfigStore userConfig, ISessionApi sessionApi, ApiSettings settings)
     {
         Home = new HomeTabViewModel(steamGameService, userConfig);
+        Settings = new SettingsTabViewModel(Home);
         SessionStart = new SessionStartViewModel(sessionApi, userConfig);
         SessionLobby = new SessionLobbyViewModel(sessionApi, userConfig);
         Swiping = new SwipingViewModel(sessionApi, userConfig, settings);
@@ -31,6 +32,8 @@ public class TabsViewModel : INotifyPropertyChanged
     public event EventHandler<MessageRequestedEventArgs>? MessageRequested;
 
     public HomeTabViewModel Home { get; }
+
+    public SettingsTabViewModel Settings { get; }
 
     private SessionStartViewModel SessionStart { get; }
 


### PR DESCRIPTION
## Summary
- add a dedicated SettingsTabView control and DataTemplate so the settings form is reusable
- expose a SettingsTabViewModel from TabsViewModel and bind it through Tabs.axaml

## Testing
- `dotnet restore ArcadeMatch.sln`
  ```
  root@2b1cbe2ea40b:/workspace/GameFinder# dotnet restore ArcadeMatch.sln
  
  Welcome to .NET 9.0!
  ---------------------
  SDK Version: 9.0.111
  
  ----------------
  Installed an ASP.NET Core HTTPS development certificate.
  To trust the certificate, run 'dotnet dev-certs https --trust'
  Learn about HTTPS: https://aka.ms/dotnet-https
  
  ----------------
  Write your first app: https://aka.ms/dotnet-hello-world
  Find out what's new: https://aka.ms/dotnet-whats-new
  Explore documentation: https://aka.ms/dotnet-docs
  Report issues and find source on GitHub: https://github.com/dotnet/core
  Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
  --------------------------------------------------------------------------------------
  
  sln                                                                                                              (1.4s)
  
  Build succeeded in 15.4s
  root@2b1cbe2ea40b:/workspace/GameFinder#
  ```
- `dotnet build --no-restore ArcadeMatch.sln`
  ```
  root@2b1cbe2ea40b:/workspace/GameFinder# dotnet build --no-restore ArcadeMatch.sln
  
  Server                                                                                                           (0.8s)
  -null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/SteamCookieFetcher/Program.cs(170,12): warning CS8618: Non-nullable property 'Value' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/SteamCookieFetcher/Program.cs(170,12): warning CS8618: Non-nullable property 'Domain' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/SteamCookieFetcher/Program.cs(170,12): warning CS8618: Non-nullable property 'Path' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/SteamCookieFetcher/Program.cs(170,12): warning CS8618: Non-nullable property 'SameSite' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/SteamCookieFetcher/Program.cs(105,20): warning CS8603: Possible null reference return.
      /workspace/GameFinder/SteamCookieFetcher/Program.cs(90,52): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
      /workspace/GameFinder/SteamCookieFetcher/Program.cs(139,20): warning CS8603: Possible null reference return.
      /workspace/GameFinder/SteamCookieFetcher/Program.cs(145,20): warning CS8603: Possible null reference return.
      /workspace/GameFinder/SteamCookieFetcher/Program.cs(148,43): warning CS8600: Converting null literal or possible null value to non-nullable type.
      /workspace/GameFinder/SteamCookieFetcher/Program.cs(151,20): warning CS8603: Possible null reference return.
  Avalonia
  Server                                                                                                           (8.0s)
  Desc' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(75,19): warning CS8618: Non-nullable property 'Url' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(61,19): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(55,19): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(8,19): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(10,19): warning CS8618: Non-nullable property 'AppType' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(12,19): warning CS8618: Non-nullable property 'ShortDescription' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(14,19): warning CS8618: Non-nullable property 'HeaderImage' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(16,24): warning CS8618: Non-nullable property 'Genres' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(18,27): warning CS8618: Non-nullable property 'Categories' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(20,19): warning CS8618: Non-nullable property 'SupportedLanguages' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(29,28): warning CS8618: Non-nullable property 'Recommendations' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(28,71): warning CS8600: Converting null literal or possible null value to non-nullable type.
      /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(74,61): warning CS8600: Converting null literal or possible null value to non-nullable type.
      /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(111,54): warning CS8600: Converting null literal or possible null value to non-nullable type.
      /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(198,53): warning CS8600: Converting null literal or possible null value to non-nullable type.
      /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(335,69): warning CS8600: Converting null literal or possible null value to non-nullable type.
      /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(354,49): warning CS8600: Converting null literal or possible null value to non-nullable type.
      /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(384,65): warning CS8600: Converting null literal or possible null value to non-nullable type.
  Core                                                                                                             (1.3s)
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(87,23): warning CS8618: Non-nullable property 'ReviewScoreDesc' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(81,23): warning CS8618: Non-nullable property 'Url' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(67,23): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(61,23): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(14,23): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(16,23): warning CS8618: Non-nullable property 'AppType' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(18,23): warning CS8618: Non-nullable property 'ShortDescription' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(20,23): warning CS8618: Non-nullable property 'HeaderImage' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(22,28): warning CS8618: Non-nullable property 'Genres' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(24,31): warning CS8618: Non-nullable property 'Categories' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(26,23): warning CS8618: Non-nullable property 'SupportedLanguages' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(35,32): warning CS8618: Non-nullable property 'Recommendations' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(8,25): warning CS8618: Non-nullable property 'Data' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Value' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Domain' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Path' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'SameSite' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(49,23): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(50,25): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(51,25): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(52,27): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(53,28): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(54,28): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(55,31): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(56,26): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(57,28): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(58,26): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(59,24): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(60,24): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(61,24): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(62,27): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(63,27): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(64,30): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(65,34): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(66,35): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(67,34): warning CS8601: Possible null reference assignment.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(7,19): warning CS8618: Non-nullable property 'SteamId' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(8,19): warning CS8618: Non-nullable property 'SteamId64' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(9,19): warning CS8618: Non-nullable property 'CustomURL' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(10,19): warning CS8618: Non-nullable property 'OnlineState' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(11,19): warning CS8618: Non-nullable property 'StateMessage' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(12,19): warning CS8618: Non-nullable property 'PrivacyState' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(13,19): warning CS8618: Non-nullable property 'VisibilityState' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(14,19): warning CS8618: Non-nullable property 'AvatarIcon' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(15,19): warning CS8618: Non-nullable property 'AvatarMedium' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(16,19): warning CS8618: Non-nullable property 'AvatarFull' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(17,19): warning CS8618: Non-nullable property 'Headline' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(18,19): warning CS8618: Non-nullable property 'Location' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(19,19): warning CS8618: Non-nullable property 'RealName' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(20,19): warning CS8618: Non-nullable property 'MemberSince' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(21,19): warning CS8618: Non-nullable property 'SteamRating' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(22,19): warning CS8618: Non-nullable property 'HoursPlayed2Wk' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(23,19): warning CS8618: Non-nullable property 'MostPlayedGameName' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(24,19): warning CS8618: Non-nullable property 'MostPlayedGameHours' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(25,19): warning CS8618: Non-nullable property 'MostPlayedGameLink' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
      /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(26,19): warning CS8618: Non-nullable property 'Groups' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
  Avalonia                                                                                                         (1.6s)
  
  Build succeeded with 87 warning(s) in 22.4s
  root@2b1cbe2ea40b:/workspace/GameFinder#
  ```

------
https://chatgpt.com/codex/tasks/task_e_690a66bc47448320b15d7f70c659f391