### PR TITLE
Unify login flows on home tab

### DIFF
--- a/ArcadeMatch.Avalonia/Controls/SettingsTabView.axaml
+++ b/ArcadeMatch.Avalonia/Controls/SettingsTabView.axaml
@@ -5,21 +5,16 @@
     xmlns:vm="clr-namespace:ArcadeMatch.Avalonia.ViewModels.Tabs"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="20">
+        <StackPanel Margin="20" Spacing="12">
             <TextBlock
                 FontSize="20"
                 FontWeight="Bold"
                 HorizontalAlignment="Center"
-                Margin="0,0,0,20"
                 Text="Configuration" />
-            <TextBlock Text="🔐 Steam API Key" />
-            <TextBox Margin="0,0,0,20" Text="{Binding Home.SteamApiKey, Mode=TwoWay}" />
-            <TextBlock Text="🆔 Steam ID" />
-            <TextBox Margin="0,0,0,20" Text="{Binding Home.SteamId, Mode=TwoWay}" />
-            <Button
-                Command="{Binding Home.FetchViaApiCommand}"
-                Content="🔄 Fetch via API"
-                HorizontalAlignment="Center" />
+            <TextBlock
+                Text="Steam authentication options now live on the Home tab so everything is in one place." />
+            <TextBlock
+                Text="Additional settings will appear here in the future." />
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/ArcadeMatch.Avalonia/Controls/Tabs.axaml
+++ b/ArcadeMatch.Avalonia/Controls/Tabs.axaml
@@ -30,21 +30,31 @@
     <TabControl>
         <TabItem Header="Home">
             <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <StackPanel Margin="20">
-                    <TextBlock
-                        FontSize="20"
-                        FontWeight="Bold"
-                        HorizontalAlignment="Center"
-                        Margin="0,0,0,10"
-                        Text="Steam Authentication" />
-                    <StackPanel Margin="0,0,0,20">
-                        <TextBlock Text="1️⃣ Click the login button below" />
-                        <TextBlock Text="2️⃣ Complete Steam authentication in browser" />
-                        <TextBlock Text="3️⃣ Click refresh to verify login status" />
-                        <TextBlock Text="4️⃣ Keep browser open until verification is complete" />
+                <StackPanel Margin="20" Spacing="20">
+                    <StackPanel Spacing="8">
+                        <TextBlock
+                            FontSize="20"
+                            FontWeight="Bold"
+                            HorizontalAlignment="Center"
+                            Text="Steam Authentication" />
+                        <TextBlock
+                            FontWeight="Bold"
+                            Text="Recommended: Use Steam API credentials" />
+                        <TextBlock
+                            Text="Provide your Steam API key and Steam ID to fetch your library without launching a browser." />
                     </StackPanel>
-                    <StackPanel Margin="0,0,0,20">
-                        <TextBlock Margin="0,0,0,10" Text="🔐 Authentication Status" />
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="🔐 Steam API Key" />
+                        <TextBox Text="{Binding Home.SteamApiKey, Mode=TwoWay}" />
+                        <TextBlock Text="🆔 Steam ID" />
+                        <TextBox Text="{Binding Home.SteamId, Mode=TwoWay}" />
+                        <Button
+                            Command="{Binding Home.FetchViaApiCommand}"
+                            Content="🔄 Fetch via API"
+                            HorizontalAlignment="Center" />
+                    </StackPanel>
+                    <StackPanel Spacing="8">
+                        <TextBlock Margin="0,0,0,2" Text="🔐 Authentication Status" />
                         <Border
                             Background="{Binding Home.IsLoggedIn, Converter={StaticResource IsLoggedInToBrushConverter}}"
                             CornerRadius="15"
@@ -63,13 +73,23 @@
                             </StackPanel>
                         </Border>
                     </StackPanel>
-                    <StackPanel
-                        HorizontalAlignment="Center"
-                        Orientation="Horizontal"
-                        Spacing="10">
-                        <Button Command="{Binding Home.LoginCommand}" Content="🔑 Login to Steam" />
-                        <Button Command="{Binding Home.RefreshCommand}" Content="🔄 Refresh Status" />
-                    </StackPanel>
+                    <Expander Header="Advanced: Use web login (not recommended)" IsExpanded="False">
+                        <StackPanel Margin="10,5,0,0" Spacing="10">
+                            <StackPanel>
+                                <TextBlock Text="1️⃣ Click the login button below" />
+                                <TextBlock Text="2️⃣ Complete Steam authentication in browser" />
+                                <TextBlock Text="3️⃣ Click refresh to verify login status" />
+                                <TextBlock Text="4️⃣ Keep browser open until verification is complete" />
+                            </StackPanel>
+                            <StackPanel
+                                HorizontalAlignment="Center"
+                                Orientation="Horizontal"
+                                Spacing="10">
+                                <Button Command="{Binding Home.LoginCommand}" Content="🔑 Login to Steam" />
+                                <Button Command="{Binding Home.RefreshCommand}" Content="🔄 Refresh Status" />
+                            </StackPanel>
+                        </StackPanel>
+                    </Expander>
                 </StackPanel>
             </ScrollViewer>
         </TabItem>


### PR DESCRIPTION
## Summary
- surface the Steam API login inputs directly on the Home tab as the recommended authentication path
- tuck the browser-based login behind an expander so it remains available but de-emphasized
- update the Settings tab to note the relocation of authentication settings

## Testing
- `dotnet restore ArcadeMatch.sln`
```
root@6e41a02332db:/workspace/GameFinder# dotnet restore ArcadeMatch.sln

Welcome to .NET 9.0!
---------------------
SDK Version: 9.0.111

----------------
Installed an ASP.NET Core HTTPS development certificate.
To trust the certificate, run 'dotnet dev-certs https --trust'
Learn about HTTPS: https://aka.ms/dotnet-https

----------------
Write your first app: https://aka.ms/dotnet-hello-world
Find out what's new: https://aka.ms/dotnet-whats-new
Explore documentation: https://aka.ms/dotnet-docs
Report issues and find source on GitHub: https://github.com/dotnet/core
Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
--------------------------------------------------------------------------------------
sln                                                                                                              (1.2s)

Build succeeded in 15.7s
```
- `dotnet build --no-restore ArcadeMatch.sln`
```
root@6e41a02332db:/workspace/GameFinder# dotnet build --no-restore ArcadeMatch.sln

Server                                                                                                           (0.9s)
-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/SteamCookieFetcher/Program.cs(170,12): warning CS8618: Non-nullable property 'Value' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/SteamCookieFetcher/Program.cs(170,12): warning CS8618: Non-nullable property 'Domain' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/SteamCookieFetcher/Program.cs(170,12): warning CS8618: Non-nullable property 'Path' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/SteamCookieFetcher/Program.cs(170,12): warning CS8618: Non-nullable property 'SameSite' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/SteamCookieFetcher/Program.cs(105,20): warning CS8603: Possible null reference return.
    /workspace/GameFinder/SteamCookieFetcher/Program.cs(90,52): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
    /workspace/GameFinder/SteamCookieFetcher/Program.cs(139,20): warning CS8603: Possible null reference return.
    /workspace/GameFinder/SteamCookieFetcher/Program.cs(145,20): warning CS8603: Possible null reference return.
    /workspace/GameFinder/SteamCookieFetcher/Program.cs(148,43): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/SteamCookieFetcher/Program.cs(151,20): warning CS8603: Possible null reference return.
  ArcadeMatch.Server succeeded with 19 warning(s) (8.3s) → ArcadeMatch.Server/bin/Debug/net9.0/ArcadeMatch.Server.dll
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(81,19): warning CS8618: Non-nullable property 'ReviewScoreDesc' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(75,19): warning CS8618: Non-nullable property 'Url' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(61,19): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(55,19): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(8,19): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(10,19): warning CS8618: Non-nullable property 'AppType' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(12,19): warning CS8618: Non-nullable property 'ShortDescription' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(14,19): warning CS8618: Non-nullable property 'HeaderImage' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(16,24): warning CS8618: Non-nullable property 'Genres' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(18,27): warning CS8618: Non-nullable property 'Categories' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(20,19): warning CS8618: Non-nullable property 'SupportedLanguages' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(29,28): warning CS8618: Non-nullable property 'Recommendations' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(28,71): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(74,61): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(111,54): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(198,53): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(335,69): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(354,49): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(384,65): warning CS8600: Converting null literal or possible null value to non-nullable type.
Core                                                                                                             (1.4s)
    /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Value' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Domain' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Path' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'SameSite' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(87,23): warning CS8618: Non-nullable property 'ReviewScoreDesc' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(81,23): warning CS8618: Non-nullable property 'Url' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(67,23): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(61,23): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(7,19): warning CS8618: Non-nullable property 'SteamId' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(8,19): warning CS8618: Non-nullable property 'SteamId64' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(9,19): warning CS8618: Non-nullable property 'CustomURL' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(10,19): warning CS8618: Non-nullable property 'OnlineState' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(11,19): warning CS8618: Non-nullable property 'StateMessage' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(12,19): warning CS8618: Non-nullable property 'PrivacyState' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(13,19): warning CS8618: Non-nullable property 'VisibilityState' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(14,19): warning CS8618: Non-nullable property 'AvatarIcon' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(15,19): warning CS8618: Non-nullable property 'AvatarMedium' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(16,19): warning CS8618: Non-nullable property 'AvatarFull' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(17,19): warning CS8618: Non-nullable property 'Headline' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(18,19): warning CS8618: Non-nullable property 'Location' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(19,19): warning CS8618: Non-nullable property 'RealName' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(20,19): warning CS8618: Non-nullable property 'MemberSince' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(21,19): warning CS8618: Non-nullable property 'SteamRating' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(22,19): warning CS8618: Non-nullable property 'HoursPlayed2Wk' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(23,19): warning CS8618: Non-nullable property 'MostPlayedGameName' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(24,19): warning CS8618: Non-nullable property 'MostPlayedGameHours' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(25,19): warning CS8618: Non-nullable property 'MostPlayedGameLink' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(26,19): warning CS8618: Non-nullable property 'Groups' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(8,25): warning CS8618: Non-nullable property 'Data' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(14,23): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(16,23): warning CS8618: Non-nullable property 'AppType' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(18,23): warning CS8618: Non-nullable property 'ShortDescription' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(20,23): warning CS8618: Non-nullable property 'HeaderImage' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(22,28): warning CS8618: Non-nullable property 'Genres' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(24,31): warning CS8618: Non-nullable property 'Categories' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(26,23): warning CS8618: Non-nullable property 'SupportedLanguages' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(35,32): warning CS8618: Non-nullable property 'Recommendations' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(49,23): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(50,25): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(51,25): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(52,27): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(53,28): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(54,28): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(55,31): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(56,26): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(57,28): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(58,26): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(59,24): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(60,24): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(61,24): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(62,27): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(63,27): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(64,30): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(65,34): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(66,35): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(67,34): warning CS8601: Possible null reference assignment.
Avalonia                                                                                                         (1.1s)

Build succeeded with 87 warning(s) in 21.7s
```


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e5f1398083208c69cad1a3add0c0)