### PR TITLE
Add Steam friends support

### DIFF
--- a/ArcadeMatch.Avalonia/App.axaml.cs
+++ b/ArcadeMatch.Avalonia/App.axaml.cs
@@ -14,6 +14,7 @@ public class App : Application
     public static IUserConfigStore UserConfig { get; private set; } = null!;
     public static ISteamGameService SteamGameService { get; private set; } = null!;
     public static IDialogService DialogService { get; private set; } = null!;
+    public static FriendsService FriendsService { get; private set; } = null!;
     public static ApiSettings Settings { get; private set; } = new();
 
     public static void InitializeServices(IServiceProvider serviceProvider)
@@ -23,6 +24,7 @@ public class App : Application
         UserConfig = serviceProvider.GetRequiredService<IUserConfigStore>();
         SteamGameService = serviceProvider.GetRequiredService<ISteamGameService>();
         DialogService = serviceProvider.GetRequiredService<IDialogService>();
+        FriendsService = serviceProvider.GetRequiredService<FriendsService>();
         Settings = serviceProvider.GetRequiredService<ApiSettings>();
     }
     

--- a/ArcadeMatch.Avalonia/ArcadeMatch.Avalonia.csproj
+++ b/ArcadeMatch.Avalonia/ArcadeMatch.Avalonia.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.2" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />

--- a/ArcadeMatch.Avalonia/Controls/FriendsTabView.axaml
+++ b/ArcadeMatch.Avalonia/Controls/FriendsTabView.axaml
@@ -1,0 +1,66 @@
+<UserControl
+    x:Class="ArcadeMatch.Avalonia.Controls.FriendsTabView"
+    x:DataType="vm:FriendsTabViewModel"
+    x:Name="Root"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:converters="clr-namespace:ArcadeMatch.Avalonia.Converters"
+    xmlns:objects="clr-namespace:GameFinder.Objects;assembly=ArcadeMatch.Core"
+    xmlns:vm="clr-namespace:ArcadeMatch.Avalonia.ViewModels.Tabs"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <UserControl.Resources>
+        <converters:BooleanToBrushConverter x:Key="BooleanToBrushConverter" />
+        <converters:StringNullOrEmptyToBoolConverter x:Key="StringNullOrEmptyToBoolConverter" />
+    </UserControl.Resources>
+    <Grid RowDefinitions="Auto,Auto,*" Margin="16" RowSpacing="12">
+        <StackPanel Orientation="Horizontal" Spacing="8">
+            <Button Content="Refresh" Command="{Binding RefreshCommand}" />
+            <TextBlock Text="Friends are fetched using your Steam API key when available, otherwise cookies." />
+        </StackPanel>
+        <TextBlock
+            Grid.Row="1"
+            Foreground="Gray"
+            IsVisible="{Binding StatusMessage, Converter={StaticResource StringNullOrEmptyToBoolConverter}}"
+            Text="{Binding StatusMessage}" />
+        <Border Grid.Row="2" BorderBrush="Gray" BorderThickness="1" CornerRadius="6" Padding="8">
+            <ScrollViewer>
+                <ItemsControl ItemsSource="{Binding Friends}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="objects:SteamFriend">
+                            <Border Margin="0,0,0,8" Padding="8" Background="{DynamicResource ThemeBackgroundBrush}" CornerRadius="4">
+                                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="12" VerticalAlignment="Center">
+                                    <Grid Width="32" Height="32">
+                                        <Ellipse Fill="Gray" />
+                                        <Ellipse>
+                                            <Ellipse.Fill>
+                                                <ImageBrush Source="{Binding AvatarUrl}" Stretch="UniformToFill" />
+                                            </Ellipse.Fill>
+                                        </Ellipse>
+                                    </Grid>
+                                    <StackPanel Grid.Column="1" Spacing="2">
+                                        <TextBlock FontWeight="Bold" Text="{Binding PersonaName}" />
+                                        <StackPanel Orientation="Horizontal" Spacing="6">
+                                            <Ellipse Width="8" Height="8" Fill="{Binding IsOnline, Converter={StaticResource BooleanToBrushConverter}}" />
+                                            <TextBlock Text="{Binding SteamId}" Foreground="Gray" />
+                                        </StackPanel>
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="6">
+                                        <Button
+                                            Content="Join"
+                                            Command="{Binding #Root.DataContext.JoinCommand}"
+                                            CommandParameter="{Binding}"
+                                            IsVisible="{Binding InSession}" />
+                                        <Button
+                                            Content="Invite"
+                                            Command="{Binding #Root.DataContext.InviteCommand}"
+                                            CommandParameter="{Binding}"
+                                            IsEnabled="{Binding IsOnline}" />
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+    </Grid>
+</UserControl>

--- a/ArcadeMatch.Avalonia/Controls/FriendsTabView.axaml.cs
+++ b/ArcadeMatch.Avalonia/Controls/FriendsTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace ArcadeMatch.Avalonia.Controls;
+
+public partial class FriendsTabView : UserControl
+{
+    public FriendsTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/ArcadeMatch.Avalonia/Controls/Tabs.axaml
+++ b/ArcadeMatch.Avalonia/Controls/Tabs.axaml
@@ -14,6 +14,9 @@
         <DataTemplate DataType="{x:Type vm:SettingsTabViewModel}">
             <controls:SettingsTabView />
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:FriendsTabViewModel}">
+            <controls:FriendsTabView />
+        </DataTemplate>
         <DataTemplate DataType="{x:Type sessionVm:SessionStartViewModel}">
             <controls:SessionStart />
         </DataTemplate>
@@ -95,6 +98,9 @@
         </TabItem>
         <TabItem Header="Session">
             <ContentControl Content="{Binding SelectedSession}" />
+        </TabItem>
+        <TabItem Header="Friends">
+            <ContentControl Content="{Binding Friends}" />
         </TabItem>
         <TabItem Header="Settings">
             <ContentControl Content="{Binding Settings}" />

--- a/ArcadeMatch.Avalonia/Controls/Tabs.axaml.cs
+++ b/ArcadeMatch.Avalonia/Controls/Tabs.axaml.cs
@@ -12,7 +12,7 @@ public partial class Tabs : UserControl
 
     public Tabs()
     {
-        _viewModel = new TabsViewModel(App.SteamGameService, App.UserConfig, App.Api, App.Settings);
+        _viewModel = new TabsViewModel(App.SteamGameService, App.UserConfig, App.Api, App.Settings, App.FriendsService);
         DataContext = _viewModel;
         _viewModel.Home.MessageRequested += OnMessageRequested;
         _viewModel.MessageRequested += OnMessageRequested;

--- a/ArcadeMatch.Avalonia/Converters/BooleanToBrushConverter.cs
+++ b/ArcadeMatch.Avalonia/Converters/BooleanToBrushConverter.cs
@@ -1,0 +1,23 @@
+using Avalonia;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace ArcadeMatch.Avalonia.Converters;
+
+public class BooleanToBrushConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+    {
+        if (value is bool flag)
+        {
+            return new SolidColorBrush(flag ? Colors.LimeGreen : Colors.Gray);
+        }
+
+        return AvaloniaProperty.UnsetValue;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/ArcadeMatch.Avalonia/Converters/StringNullOrEmptyToBoolConverter.cs
+++ b/ArcadeMatch.Avalonia/Converters/StringNullOrEmptyToBoolConverter.cs
@@ -1,0 +1,20 @@
+using Avalonia;
+using Avalonia.Data.Converters;
+
+namespace ArcadeMatch.Avalonia.Converters;
+
+public class StringNullOrEmptyToBoolConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+    {
+        bool invert = parameter is string text && bool.TryParse(text, out bool parsed) && parsed;
+        bool hasText = value is string str && !string.IsNullOrWhiteSpace(str);
+        bool result = invert ? !hasText : hasText;
+        return result;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+    {
+        return AvaloniaProperty.UnsetValue;
+    }
+}

--- a/ArcadeMatch.Avalonia/Program.cs
+++ b/ArcadeMatch.Avalonia/Program.cs
@@ -27,11 +27,16 @@ static class Program
     private static IServiceProvider ConfigureServices()
     {
         var services = new ServiceCollection();
+        services.AddMemoryCache();
         services.AddSingleton<ApiSettings>(_ => ApiSettings.Load());
         services.AddSingleton<IUserConfigStore, UserConfigStore>();
         services.AddSingleton<ISteamGameService, SteamGameService>();
         services.AddSingleton<ISessionApi, ApiHandler>();
         services.AddSingleton<IDialogService, DialogService>();
+        services.AddSingleton<SteamFriendCache>();
+        services.AddSingleton<CookieSteamFriendsProvider>();
+        services.AddSingleton<ApiSteamFriendsProvider>();
+        services.AddSingleton<FriendsService>();
         return services.BuildServiceProvider();
     }
 }

--- a/ArcadeMatch.Avalonia/Services/ApiSteamFriendsProvider.cs
+++ b/ArcadeMatch.Avalonia/Services/ApiSteamFriendsProvider.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using GameFinder.Objects;
+
+namespace ArcadeMatch.Avalonia.Services;
+
+public sealed class ApiSteamFriendsProvider : ISteamFriendsProvider
+{
+    private const int BatchSize = 100;
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(20)
+    };
+
+    private readonly SteamFriendCache _cache;
+
+    public ApiSteamFriendsProvider(SteamFriendCache cache)
+    {
+        _cache = cache;
+    }
+
+    public async Task<IReadOnlyList<SteamFriend>> GetFriendsAsync(
+        string steamId,
+        string? apiKey,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new InvalidOperationException("Steam API key is required to load friends via the Web API.");
+        }
+
+        if (string.IsNullOrWhiteSpace(steamId))
+        {
+            throw new InvalidOperationException("Steam ID is required to load friends via the Web API.");
+        }
+
+        string validApiKey = apiKey!;
+
+        IReadOnlyList<string> friendIds = await GetFriendIdsAsync(validApiKey, steamId, cancellationToken).ConfigureAwait(false);
+        if (friendIds.Count == 0)
+        {
+            return Array.Empty<SteamFriend>();
+        }
+
+        var friends = new List<SteamFriend>(friendIds.Count);
+        for (int i = 0; i < friendIds.Count; i += BatchSize)
+        {
+            var batch = friendIds.Skip(i).Take(BatchSize).ToList();
+            var summaries = await GetPlayerSummariesAsync(validApiKey, batch, cancellationToken).ConfigureAwait(false);
+            friends.AddRange(summaries);
+        }
+
+        return friends
+            .OrderByDescending(friend => friend.IsOnline)
+            .ThenBy(friend => friend.PersonaName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static async Task<IReadOnlyList<string>> GetFriendIdsAsync(string apiKey, string steamId, CancellationToken cancellationToken)
+    {
+        string url = $"https://api.steampowered.com/ISteamUser/GetFriendList/v0001/?key={apiKey}&steamid={steamId}&relationship=friend";
+        using HttpResponseMessage response = await HttpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using Stream responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using JsonDocument json = await JsonDocument.ParseAsync(responseStream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!json.RootElement.TryGetProperty("friendslist", out JsonElement friendsList) ||
+            !friendsList.TryGetProperty("friends", out JsonElement friendsArray))
+        {
+            return Array.Empty<string>();
+        }
+
+        return friendsArray
+            .EnumerateArray()
+            .Select(element => element.TryGetProperty("steamid", out JsonElement idElement) ? idElement.GetString() : null)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<SteamFriend>> GetPlayerSummariesAsync(string apiKey, IReadOnlyList<string> steamIds, CancellationToken cancellationToken)
+    {
+        string joinedIds = string.Join(',', steamIds);
+        string url = $"https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/?key={apiKey}&steamids={joinedIds}";
+        using HttpResponseMessage response = await HttpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using Stream responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using JsonDocument json = await JsonDocument.ParseAsync(responseStream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!json.RootElement.TryGetProperty("response", out JsonElement root) ||
+            !root.TryGetProperty("players", out JsonElement players))
+        {
+            return Array.Empty<SteamFriend>();
+        }
+
+        List<SteamFriend> friends = new();
+        foreach (JsonElement player in players.EnumerateArray())
+        {
+            string? steamId = player.TryGetProperty("steamid", out JsonElement idElement) ? idElement.GetString() : null;
+            if (string.IsNullOrWhiteSpace(steamId))
+            {
+                continue;
+            }
+
+            string personaName = player.TryGetProperty("personaname", out JsonElement nameElement)
+                ? nameElement.GetString() ?? steamId
+                : steamId;
+
+            string? avatar = player.TryGetProperty("avatarfull", out JsonElement avatarElement)
+                ? avatarElement.GetString()
+                : null;
+
+            bool isOnline = player.TryGetProperty("personastate", out JsonElement stateElement) && stateElement.GetInt32() != 0;
+
+            friends.Add(new SteamFriend(steamId, personaName, avatar, isOnline));
+            _cache.Set(steamId, new CachedSteamFriend(personaName, avatar, isOnline));
+        }
+
+        return friends;
+    }
+}

--- a/ArcadeMatch.Avalonia/Services/CookieSteamFriendsProvider.cs
+++ b/ArcadeMatch.Avalonia/Services/CookieSteamFriendsProvider.cs
@@ -1,0 +1,135 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Xml.Linq;
+using GameFinder.Objects;
+using SeleniumCookie = OpenQA.Selenium.Cookie;
+
+namespace ArcadeMatch.Avalonia.Services;
+
+public sealed class CookieSteamFriendsProvider : ISteamFriendsProvider
+{
+    private static readonly Uri SteamCommunityBaseUri = new("https://steamcommunity.com/");
+    private static readonly SemaphoreSlim Throttle = new(10);
+
+    private readonly ISteamGameService _steamGameService;
+    private readonly SteamFriendCache _cache;
+
+    public CookieSteamFriendsProvider(ISteamGameService steamGameService, SteamFriendCache cache)
+    {
+        _steamGameService = steamGameService;
+        _cache = cache;
+    }
+
+    public async Task<IReadOnlyList<SteamFriend>> GetFriendsAsync(
+        string steamId,
+        string? apiKey,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(steamId))
+        {
+            throw new InvalidOperationException("Steam ID is required to load friends.");
+        }
+
+        IReadOnlyCollection<SeleniumCookie>? cookies = _steamGameService.LoadCookies();
+        if (cookies == null || cookies.Count == 0)
+        {
+            throw new InvalidOperationException("Steam login required to retrieve friends list.");
+        }
+
+        using HttpClient client = CreateHttpClient(cookies);
+        XDocument profileDocument = await LoadProfileAsync(client, steamId, cancellationToken).ConfigureAwait(false);
+        var friendIds = profileDocument
+            .Descendants("friend")
+            .Select(node => node.Value)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (friendIds.Count == 0)
+        {
+            return Array.Empty<SteamFriend>();
+        }
+
+        var friends = new ConcurrentBag<SteamFriend>();
+        var tasks = friendIds.Select(id => FetchFriendAsync(client, id, friends, cancellationToken));
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        return friends
+            .OrderByDescending(friend => friend.IsOnline)
+            .ThenBy(friend => friend.PersonaName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static HttpClient CreateHttpClient(IReadOnlyCollection<SeleniumCookie> cookies)
+    {
+        HttpClientHandler handler = new()
+        {
+            CookieContainer = new CookieContainer(),
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+        };
+
+        foreach (SeleniumCookie cookie in cookies)
+        {
+            System.Net.Cookie netCookie = new(cookie.Name, cookie.Value, cookie.Path, cookie.Domain)
+            {
+                Secure = cookie.Secure,
+                HttpOnly = cookie.IsHttpOnly
+            };
+            if (cookie.Expiry is DateTime expiry)
+            {
+                netCookie.Expires = expiry;
+            }
+            handler.CookieContainer.Add(SteamCommunityBaseUri, netCookie);
+        }
+
+        return new HttpClient(handler, disposeHandler: true)
+        {
+            Timeout = TimeSpan.FromSeconds(20)
+        };
+    }
+
+    private static async Task<XDocument> LoadProfileAsync(HttpClient client, string steamId, CancellationToken cancellationToken)
+    {
+        string url = $"https://steamcommunity.com/profiles/{steamId}/?xml=1";
+        await using Stream stream = await client.GetStreamAsync(url, cancellationToken).ConfigureAwait(false);
+        return await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task FetchFriendAsync(HttpClient client, string friendId, ConcurrentBag<SteamFriend> friends, CancellationToken cancellationToken)
+    {
+        if (_cache.TryGet(friendId, out CachedSteamFriend cached))
+        {
+            friends.Add(new SteamFriend(friendId, cached.PersonaName, cached.AvatarUrl, cached.IsOnline ?? false));
+            return;
+        }
+
+        await Throttle.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            XDocument friendProfile = await LoadProfileAsync(client, friendId, cancellationToken).ConfigureAwait(false);
+            XElement? profile = friendProfile.Element("profile");
+            if (profile == null)
+            {
+                return;
+            }
+
+            string personaName = profile.Element("steamID")?.Value ?? friendId;
+            string? avatar = profile.Element("avatarFull")?.Value;
+            string? state = profile.Element("onlineState")?.Value;
+            bool isOnline = !string.Equals(state, "offline", StringComparison.OrdinalIgnoreCase);
+
+            CachedSteamFriend cacheEntry = new(personaName, avatar, isOnline);
+            _cache.Set(friendId, cacheEntry);
+
+            friends.Add(new SteamFriend(friendId, personaName, avatar, isOnline));
+        }
+        catch
+        {
+            friends.Add(new SteamFriend(friendId, friendId, null, false));
+        }
+        finally
+        {
+            Throttle.Release();
+        }
+    }
+}

--- a/ArcadeMatch.Avalonia/Services/FriendsService.cs
+++ b/ArcadeMatch.Avalonia/Services/FriendsService.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using GameFinder.Objects;
+
+namespace ArcadeMatch.Avalonia.Services;
+
+public sealed class FriendsService
+{
+    private readonly CookieSteamFriendsProvider _cookieProvider;
+    private readonly ApiSteamFriendsProvider _apiProvider;
+    private readonly ISessionApi _sessionApi;
+    private readonly IUserConfigStore _configStore;
+
+    public FriendsService(
+        CookieSteamFriendsProvider cookieProvider,
+        ApiSteamFriendsProvider apiProvider,
+        ISessionApi sessionApi,
+        IUserConfigStore configStore)
+    {
+        _cookieProvider = cookieProvider;
+        _apiProvider = apiProvider;
+        _sessionApi = sessionApi;
+        _configStore = configStore;
+    }
+
+    public async Task<IReadOnlyList<SteamFriend>> GetFriendsAsync(CancellationToken cancellationToken = default)
+    {
+        string? steamId = _configStore.SteamId;
+        if (string.IsNullOrWhiteSpace(steamId))
+        {
+            throw new InvalidOperationException("Steam ID is required. Provide it on the Home tab and try again.");
+        }
+
+        IReadOnlyList<SteamFriend> friends = await FetchFriendsAsync(steamId, cancellationToken).ConfigureAwait(false);
+        if (friends.Count == 0)
+        {
+            return friends;
+        }
+
+        var steamIds = friends.Select(friend => friend.SteamId).ToList();
+        IDictionary<string, string> sessions = await _sessionApi.GetFriendsSessionsAsync(steamIds).ConfigureAwait(false);
+
+        return friends
+            .Select(friend => sessions.TryGetValue(friend.SteamId, out string? sessionCode)
+                ? friend with { InSession = true, SessionCode = sessionCode }
+                : friend with { InSession = false, SessionCode = null })
+            .OrderByDescending(friend => friend.InSession)
+            .ThenByDescending(friend => friend.IsOnline)
+            .ThenBy(friend => friend.PersonaName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<SteamFriend>> FetchFriendsAsync(string steamId, CancellationToken cancellationToken)
+    {
+        string apiKey = _configStore.SteamApiKey;
+        if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            return await _apiProvider.GetFriendsAsync(steamId, apiKey, cancellationToken).ConfigureAwait(false);
+        }
+
+        return await _cookieProvider.GetFriendsAsync(steamId, null, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/ArcadeMatch.Avalonia/Services/ISessionApi.cs
+++ b/ArcadeMatch.Avalonia/Services/ISessionApi.cs
@@ -18,14 +18,22 @@ public interface ISessionApi
     event Action<string>? ErrorOccurred;
     event Action<IReadOnlyList<MatchedGame>>? SessionEnded;
     event Action<IReadOnlyList<string>, string?>? SessionStateReceived;
+    event Action<string, string>? InviteReceived;
 
     Task Connect(string[] args);
     Task CreateSessionAsync();
-    Task JoinSessionAsync(string sessionCode, string username, IEnumerable<string> gameList, IEnumerable<string> wishlist);
+    Task JoinSessionAsync(
+        string sessionCode,
+        string username,
+        IEnumerable<string> gameList,
+        IEnumerable<string> wishlist,
+        string? steamId = null);
     Task LeaveSessionAsync(string username);
     Task StartSession(string sessionCode, bool includeWishlist, int minOwners, int minWishlisted);
     Task Swipe(string sessionCode, string game, bool swipeRight);
     Task EndSession(string sessionCode);
     Task<IReadOnlyList<MatchedGame>> ResolveGamesAsync(IEnumerable<MatchedGameSummary> gameSummaries);
     Task<MatchedGame?> ResolveGameAsync(string gameId, int likes = 0, int totalParticipants = 0);
+    Task<IDictionary<string, string>> GetFriendsSessionsAsync(IEnumerable<string> friendSteamIds);
+    Task InviteFriendAsync(string friendSteamId);
 }

--- a/ArcadeMatch.Avalonia/Services/ISteamFriendsProvider.cs
+++ b/ArcadeMatch.Avalonia/Services/ISteamFriendsProvider.cs
@@ -1,0 +1,11 @@
+using GameFinder.Objects;
+
+namespace ArcadeMatch.Avalonia.Services;
+
+public interface ISteamFriendsProvider
+{
+    Task<IReadOnlyList<SteamFriend>> GetFriendsAsync(
+        string steamId,
+        string? apiKey,
+        CancellationToken cancellationToken = default);
+}

--- a/ArcadeMatch.Avalonia/Services/SteamFriendCache.cs
+++ b/ArcadeMatch.Avalonia/Services/SteamFriendCache.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace ArcadeMatch.Avalonia.Services;
+
+public sealed class SteamFriendCache
+{
+    private static readonly TimeSpan DefaultExpiration = TimeSpan.FromMinutes(15);
+
+    private readonly IMemoryCache _memoryCache;
+
+    public SteamFriendCache(IMemoryCache memoryCache)
+    {
+        _memoryCache = memoryCache;
+    }
+
+    public bool TryGet(string steamId, out CachedSteamFriend friend)
+    {
+        if (_memoryCache.TryGetValue(steamId, out CachedSteamFriend? cached) && cached != null)
+        {
+            friend = cached;
+            return true;
+        }
+
+        friend = default!;
+        return false;
+    }
+
+    public void Set(string steamId, CachedSteamFriend friend)
+    {
+        _memoryCache.Set(
+            steamId,
+            friend,
+            new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = DefaultExpiration
+            });
+    }
+}
+
+public sealed record class CachedSteamFriend(string PersonaName, string? AvatarUrl, bool? IsOnline);

--- a/ArcadeMatch.Avalonia/ViewModels/Sessions/SessionStartViewModel.cs
+++ b/ArcadeMatch.Avalonia/ViewModels/Sessions/SessionStartViewModel.cs
@@ -86,7 +86,8 @@ public class SessionStartViewModel : INotifyPropertyChanged, IDisposable
             _sessionApi.SessionId!,
             DisplayName,
             _userConfig.GameList,
-            _userConfig.WishlistGames).ConfigureAwait(false);
+            _userConfig.WishlistGames,
+            _userConfig.SteamId).ConfigureAwait(false);
 
         OnNavigationRequested(SessionViewType.Lobby);
     }
@@ -109,7 +110,8 @@ public class SessionStartViewModel : INotifyPropertyChanged, IDisposable
             SessionCode,
             DisplayName,
             _userConfig.GameList,
-            _userConfig.WishlistGames).ConfigureAwait(false);
+            _userConfig.WishlistGames,
+            _userConfig.SteamId).ConfigureAwait(false);
 
         OnNavigationRequested(SessionViewType.Lobby);
     }

--- a/ArcadeMatch.Avalonia/ViewModels/Tabs/FriendsTabViewModel.cs
+++ b/ArcadeMatch.Avalonia/ViewModels/Tabs/FriendsTabViewModel.cs
@@ -1,0 +1,227 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using ArcadeMatch.Avalonia.Commands;
+using ArcadeMatch.Avalonia.Services;
+using ArcadeMatch.Avalonia.ViewModels;
+using Avalonia.Threading;
+using GameFinder.Objects;
+
+namespace ArcadeMatch.Avalonia.ViewModels.Tabs;
+
+public class FriendsTabViewModel : INotifyPropertyChanged, IDisposable
+{
+    private readonly FriendsService _friendsService;
+    private readonly IUserConfigStore _configStore;
+    private readonly ISessionApi _sessionApi;
+
+    private readonly ObservableCollection<SteamFriend> _friends = new();
+    private string? _statusMessage;
+    private bool _isLoading;
+
+    public FriendsTabViewModel(FriendsService friendsService, IUserConfigStore configStore, ISessionApi sessionApi)
+    {
+        _friendsService = friendsService;
+        _configStore = configStore;
+        _sessionApi = sessionApi;
+
+        Friends = new ReadOnlyObservableCollection<SteamFriend>(_friends);
+
+        RefreshCommand = new AsyncCommand(RefreshAsync);
+        InviteCommand = new AsyncCommand(
+            parameter => InviteFriendAsync(parameter as SteamFriend),
+            parameter => parameter is SteamFriend);
+        JoinCommand = new AsyncCommand(
+            parameter => JoinFriendAsync(parameter as SteamFriend),
+            parameter => parameter is SteamFriend friend && friend.InSession);
+
+        _sessionApi.InviteReceived += OnInviteReceived;
+        _sessionApi.ErrorOccurred += OnErrorOccurred;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public event EventHandler<MessageRequestedEventArgs>? MessageRequested;
+
+    public ReadOnlyObservableCollection<SteamFriend> Friends { get; }
+
+    public ICommand RefreshCommand { get; }
+
+    public ICommand InviteCommand { get; }
+
+    public ICommand JoinCommand { get; }
+
+    public bool IsLoading
+    {
+        get => _isLoading;
+        private set
+        {
+            if (_isLoading == value)
+            {
+                return;
+            }
+
+            _isLoading = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string? StatusMessage
+    {
+        get => _statusMessage;
+        private set
+        {
+            if (string.Equals(_statusMessage, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _statusMessage = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public void Dispose()
+    {
+        _sessionApi.InviteReceived -= OnInviteReceived;
+        _sessionApi.ErrorOccurred -= OnErrorOccurred;
+    }
+
+    public async Task InitializeAsync()
+    {
+        if (_friends.Count == 0)
+        {
+            await RefreshAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task RefreshAsync()
+    {
+        try
+        {
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                IsLoading = true;
+                StatusMessage = null;
+            });
+
+            IReadOnlyList<SteamFriend> friends = await _friendsService.GetFriendsAsync().ConfigureAwait(false);
+
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                UpdateFriends(friends);
+                if (friends.Count == 0)
+                {
+                    StatusMessage = "No friends found. Confirm your Steam account privacy settings.";
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            await Dispatcher.UIThread.InvokeAsync(() => StatusMessage = ex.Message);
+            MessageRequested?.Invoke(this, new MessageRequestedEventArgs("Friends", ex.Message));
+        }
+        finally
+        {
+            await Dispatcher.UIThread.InvokeAsync(() => IsLoading = false);
+        }
+    }
+
+    private void UpdateFriends(IReadOnlyList<SteamFriend> friends)
+    {
+        _friends.Clear();
+        foreach (SteamFriend friend in friends)
+        {
+            _friends.Add(friend);
+        }
+
+        if (JoinCommand is AsyncCommand joinCommand)
+        {
+            joinCommand.RaiseCanExecuteChanged();
+        }
+
+        if (InviteCommand is AsyncCommand inviteCommand)
+        {
+            inviteCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    private async Task InviteFriendAsync(SteamFriend? friend)
+    {
+        if (friend == null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_sessionApi.SessionId))
+        {
+            MessageRequested?.Invoke(this, new MessageRequestedEventArgs("Invite", "Start or join a session before sending invites."));
+            return;
+        }
+
+        try
+        {
+            await _sessionApi.InviteFriendAsync(friend.SteamId).ConfigureAwait(false);
+            MessageRequested?.Invoke(this, new MessageRequestedEventArgs("Invite", $"Invite sent to {friend.PersonaName}."));
+        }
+        catch (Exception ex)
+        {
+            MessageRequested?.Invoke(this, new MessageRequestedEventArgs("Invite", ex.Message));
+        }
+    }
+
+    private async Task JoinFriendAsync(SteamFriend? friend)
+    {
+        if (friend == null || string.IsNullOrWhiteSpace(friend.SessionCode))
+        {
+            return;
+        }
+
+        string? username = _configStore.Username;
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            username = _configStore.UserProfile?.SteamId ?? _configStore.SteamId;
+        }
+
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            MessageRequested?.Invoke(this, new MessageRequestedEventArgs("Join", "Set a display name on the Session tab before joining."));
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(_sessionApi.SessionId) &&
+            !string.Equals(_sessionApi.SessionId, friend.SessionCode, StringComparison.Ordinal))
+        {
+            await _sessionApi.LeaveSessionAsync(username).ConfigureAwait(false);
+        }
+
+        try
+        {
+            await _sessionApi.JoinSessionAsync(
+                friend.SessionCode,
+                username,
+                _configStore.GameList,
+                _configStore.WishlistGames,
+                _configStore.SteamId).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            MessageRequested?.Invoke(this, new MessageRequestedEventArgs("Join", ex.Message));
+        }
+    }
+
+    private void OnInviteReceived(string sessionCode, string inviter)
+    {
+        MessageRequested?.Invoke(this, new MessageRequestedEventArgs("Invite Received", $"{inviter} invited you to join session {sessionCode}."));
+    }
+
+    private void OnErrorOccurred(string error)
+    {
+        MessageRequested?.Invoke(this, new MessageRequestedEventArgs("Error", error));
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/ArcadeMatch.Avalonia/ViewModels/Tabs/TabsViewModel.cs
+++ b/ArcadeMatch.Avalonia/ViewModels/Tabs/TabsViewModel.cs
@@ -9,16 +9,23 @@ namespace ArcadeMatch.Avalonia.ViewModels.Tabs;
 
 public class TabsViewModel : INotifyPropertyChanged
 {
-    public TabsViewModel(ISteamGameService steamGameService, IUserConfigStore userConfig, ISessionApi sessionApi, ApiSettings settings)
+    public TabsViewModel(
+        ISteamGameService steamGameService,
+        IUserConfigStore userConfig,
+        ISessionApi sessionApi,
+        ApiSettings settings,
+        FriendsService friendsService)
     {
         Home = new HomeTabViewModel(steamGameService, userConfig);
         Settings = new SettingsTabViewModel(Home);
+        Friends = new FriendsTabViewModel(friendsService, userConfig, sessionApi);
         SessionStart = new SessionStartViewModel(sessionApi, userConfig);
         SessionLobby = new SessionLobbyViewModel(sessionApi, userConfig);
         Swiping = new SwipingViewModel(sessionApi, userConfig, settings);
         MatchResult = new MatchResultViewModel();
 
         SubscribeToMessages(SessionStart, SessionLobby, Swiping);
+        Friends.MessageRequested += (_, e) => MessageRequested?.Invoke(this, e);
         MatchResult.NavigationRequested += OnNavigationRequested;
 
         SessionStart.NavigationRequested += OnNavigationRequested;
@@ -34,6 +41,8 @@ public class TabsViewModel : INotifyPropertyChanged
     public HomeTabViewModel Home { get; }
 
     public SettingsTabViewModel Settings { get; }
+
+    public FriendsTabViewModel Friends { get; }
 
     private SessionStartViewModel SessionStart { get; }
 
@@ -61,6 +70,7 @@ public class TabsViewModel : INotifyPropertyChanged
     public async Task InitializeAsync()
     {
         await Home.InitializeAsync().ConfigureAwait(false);
+        await Friends.InitializeAsync().ConfigureAwait(false);
     }
 
     private void OnNavigationRequested(object? sender, SessionNavigationEventArgs e)

--- a/ArcadeMatch.Core/Objects/SteamFriend.cs
+++ b/ArcadeMatch.Core/Objects/SteamFriend.cs
@@ -1,0 +1,12 @@
+namespace GameFinder.Objects;
+
+public record class SteamFriend(
+    string SteamId,
+    string PersonaName,
+    string? AvatarUrl,
+    bool IsOnline)
+{
+    public bool InSession { get; init; }
+
+    public string? SessionCode { get; init; }
+}


### PR DESCRIPTION
## Summary
- add Steam friend providers with caching and a coordinating friends service in the Avalonia client
- introduce a Friends tab UI and view model that can refresh, invite, and join friends, wiring up new SignalR API surface
- extend the server hub and session API to track Steam IDs, report active friend sessions, and deliver invites

## Testing
```
dotnet restore ArcadeMatch.sln
Restore complete (2.8s)

Build succeeded in 3.5s
```
```
dotnet build --no-restore ArcadeMatch.sln
SteamCookieFetcher
Server                                                                                                           (1.0s)
Desc' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(75,19): warning CS8618: Non-nullable property 'Url' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(61,19): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(55,19): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(8,19): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(10,19): warning CS8618: Non-nullable property 'AppType' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(12,19): warning CS8618: Non-nullable property 'ShortDescription' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(14,19): warning CS8618: Non-nullable property 'HeaderImage' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(16,24): warning CS8618: Non-nullable property 'Genres' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(18,27): warning CS8618: Non-nullable property 'Categories' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(20,19): warning CS8618: Non-nullable property 'SupportedLanguages' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/Objects/SteamResponse.cs(29,28): warning CS8618: Non-nullable property 'Recommendations' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(33,72): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(39,71): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(90,61): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(127,54): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(174,76): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(231,53): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(417,69): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(436,49): warning CS8600: Converting null literal or possible null value to non-nullable type.
    /workspace/GameFinder/ArcadeMatch.Server/MatchingHub.cs(466,65): warning CS8600: Converting null literal or possible null value to non-nullable type.
  ArcadeMatch.Core succeeded with 57 warning(s) (1.1s) → ArcadeMatch.Core/bin/Debug/net8.0/ArcadeMatch.Core.dll
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(87,23): warning CS8618: Non-nullable property 'ReviewScoreDesc' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Value' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Domain' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'Path' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/CookieData.cs(16,12): warning CS8618: Non-nullable property 'SameSite' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(81,23): warning CS8618: Non-nullable property 'Url' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(7,19): warning CS8618: Non-nullable property 'SteamId' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(8,19): warning CS8618: Non-nullable property 'SteamId64' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(9,19): warning CS8618: Non-nullable property 'CustomURL' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(10,19): warning CS8618: Non-nullable property 'OnlineState' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(11,19): warning CS8618: Non-nullable property 'StateMessage' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(12,19): warning CS8618: Non-nullable property 'PrivacyState' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(13,19): warning CS8618: Non-nullable property 'VisibilityState' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(14,19): warning CS8618: Non-nullable property 'AvatarIcon' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(15,19): warning CS8618: Non-nullable property 'AvatarMedium' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(16,19): warning CS8618: Non-nullable property 'AvatarFull' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(17,19): warning CS8618: Non-nullable property 'Headline' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(18,19): warning CS8618: Non-nullable property 'Location' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(19,19): warning CS8618: Non-nullable property 'RealName' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(20,19): warning CS8618: Non-nullable property 'MemberSince' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(21,19): warning CS8618: Non-nullable property 'SteamRating' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(22,19): warning CS8618: Non-nullable property 'HoursPlayed2Wk' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(23,19): warning CS8618: Non-nullable property 'MostPlayedGameName' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(24,19): warning CS8618: Non-nullable property 'MostPlayedGameHours' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(25,19): warning CS8618: Non-nullable property 'MostPlayedGameLink' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(26,19): warning CS8618: Non-nullable property 'Groups' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(8,25): warning CS8618: Non-nullable property 'Data' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(61,23): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(67,23): warning CS8618: Non-nullable property 'Description' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(14,23): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(16,23): warning CS8618: Non-nullable property 'AppType' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(18,23): warning CS8618: Non-nullable property 'ShortDescription' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(20,23): warning CS8618: Non-nullable property 'HeaderImage' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(22,28): warning CS8618: Non-nullable property 'Genres' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(24,31): warning CS8618: Non-nullable property 'Categories' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(26,23): warning CS8618: Non-nullable property 'SupportedLanguages' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamResponse.cs(35,32): warning CS8618: Non-nullable property 'Recommendations' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(49,23): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(50,25): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(51,25): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(52,27): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(53,28): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(54,28): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(55,31): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(56,26): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(57,28): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(58,26): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(59,24): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(60,24): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(61,24): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(62,27): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(63,27): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(64,30): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(65,34): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(66,35): warning CS8601: Possible null reference assignment.
    /workspace/GameFinder/ArcadeMatch.Core/Objects/SteamProfileFetcher.cs(67,34): warning CS8601: Possible null reference assignment.
SteamCookieFetcher                                                                                               (2.6s)
Avalonia

Build succeeded with 89 warning(s) in 11.7s
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911f63fefd4832086d3b0eca2c6c302)